### PR TITLE
chore: Added support for reading quey from a file

### DIFF
--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/fatih/color"
 	"os"
 	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/fatih/color"
 
 	log "github.com/sirupsen/logrus"
 

--- a/internal/install/recipes/process_evaluator.go
+++ b/internal/install/recipes/process_evaluator.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/newrelic/newrelic-cli/internal/install/execution"
 	"golang.org/x/exp/slices"
+
+	"github.com/newrelic/newrelic-cli/internal/install/execution"
 
 	"github.com/shirou/gopsutil/v3/process"
 	log "github.com/sirupsen/logrus"


### PR DESCRIPTION
Prior to this change, trying to do the following will result in an error:

```sh
$ newrelic nrql query --query <(cat some.nrql)
```

With this change, we support proper shell redirection. And, technically, the following will also work:

```sh
$ newrelic nrql query --query ./some.nrql
```